### PR TITLE
Make Twitter reports use HTTPS URLs. (Again.)

### DIFF
--- a/scripts/StreamReader/StreamTwitter.pl
+++ b/scripts/StreamReader/StreamTwitter.pl
@@ -109,7 +109,7 @@ while (my $line = <$read_pipe>) {
     my $subscribers = $core->value_get('feed_reader:subscribers',"Twitter$author");
     foreach my $channel (split(',',$subscribers)) {
       if($channel ne '#minecraft' || !$tweet->{'in_reply_to_user_id'} || $mojangles{$tweet->{'in_reply_to_user_id'}}) {
-        $core->server_send("PRIVMSG $channel :\x02Tweet\x02 (by \x0303\@$author\x0F) $text [ http://twitter.com/$author/status/$id ]");
+        $core->server_send("PRIVMSG $channel :\x02Tweet\x02 (by \x0303\@$author\x0F) $text [ https://twitter.com/$author/status/$id ]");
       }
     }
   }


### PR DESCRIPTION
This pull request supersedes its previous version, #22, which no longer applies due to the rewrite of the relevant script.

I have closed the superseded #22.
