### PR TITLE
Clean up forum post report timestamps.

### DIFF
--- a/scripts/FeedReader/FeedFrogatto.pl
+++ b/scripts/FeedReader/FeedFrogatto.pl
@@ -37,14 +37,13 @@ foreach my $current_feed (@feed_array) {
 
     my ($data_link,$item_id,$data_author,$data_title,$data_date_full) = entry_to_data($current_entry,$link_regex,$item_id_regex,$author_regex,$title_regex,$date_regex);
     #2011-06-07T05:09:07Z
-    $data_date_full =~ m/^([0-9]+)-([0-9]+)-([0-9]+)T([0-9]+):([0-9]+):([0-9]+)Z$/i;
-    my $data_date = "$2-$3-$1";
-    my $data_time = "$4:$5";
+    $data_date_full =~ m/^([0-9]+-[0-9]+-[0-9]+)T([0-9]+:[0-9]+):[0-9]+Z$/i;
+    my $data_time = "$1 $2 UTC";
 
     if(check_new($data_site,$current_feed,$item_id)) {
       commit_entry($data_site,$current_feed,$item_id);
       foreach my $current_subscriber (@subscribers_array) {
-        $FeedReader::core->server_send("PRIVMSG $current_subscriber :\x02Frogatto Forums\x02 | \x02$data_title\x02 by \x0303$data_author\x0F [ \x0314$data_date $data_time\x0F ] [ $data_link ]");
+        $FeedReader::core->server_send("PRIVMSG $current_subscriber :\x02Frogatto Forums\x02 | \x02$data_title\x02 by \x0303$data_author\x0F [ \x0314$data_time\x0F ] [ $data_link ]");
       }
     }
   }

--- a/scripts/FeedReader/FeedTribalHero.pl
+++ b/scripts/FeedReader/FeedTribalHero.pl
@@ -30,15 +30,14 @@ foreach my $current_feed (@feed_array) {
 
     my ($data_link,$item_id,$data_author,$data_title,$data_date_full) = entry_to_data($current_entry,$link_regex,$item_id_regex,$author_regex,$title_regex,$date_regex);
     #2011-06-04T14:23:22-05:00
-    $data_date_full =~ m/^([0-9]+)-([0-9]+)-([0-9]+)T([0-9]+):([0-9]+):([0-9]+)[+-][0-9]+:[0-9]+$/i;
-    my $data_date = "$2-$3-$1";
-    my $data_time = "$4:$5";
+    $data_date_full =~ m/^([0-9]+-[0-9]+-[0-9]+)T([0-9]+:[0-9]+):[0-9]+([+-][0-9]+:[0-9]+)$/i;
+    my $data_time = "$1 $2 $3";
 
     if(check_new($data_site,$current_feed,$item_id)) {
       commit_entry($data_site,$current_feed,$item_id);
       foreach my $current_subscriber (@subscribers_array) {
         #http://forums.tribalhero.com/viewtopic.php?t=35139&p=508432#p508432
-        $FeedReader::core->server_send("PRIVMSG $current_subscriber :\x02Tribalhero Forums\x02 | \x02$data_title\x02 by \x0303$data_author\x0F [ \x0314$data_date $data_time\x0F ] [ $data_link ]");
+        $FeedReader::core->server_send("PRIVMSG $current_subscriber :\x02Tribalhero Forums\x02 | \x02$data_title\x02 by \x0303$data_author\x0F [ \x0314$data_time\x0F ] [ $data_link ]");
       }
     }
   }

--- a/scripts/FeedReader/FeedUnknownHorizons.pl
+++ b/scripts/FeedReader/FeedUnknownHorizons.pl
@@ -31,14 +31,13 @@ foreach my $current_feed (@feed_array) {
 
     my ($data_link,$item_id,$data_author,$data_title,$data_date_full) = entry_to_data($current_entry,$link_regex,$item_id_regex,$author_regex,$title_regex,$date_regex);
     #2011-06-04T14:23:22-05:00
-    $data_date_full =~ m/^([0-9]+)-([0-9]+)-([0-9]+)T([0-9]+):([0-9]+):([0-9]+)[+-][0-9]+:[0-9]+$/i;
-    my $data_date = "$2-$3-$1";
-    my $data_time = "$4:$5";
+    $data_date_full =~ m/^([0-9]+-[0-9]+-[0-9]+)T([0-9]+:[0-9]+):[0-9]+([+-][0-9]+:[0-9]+)$/i;
+    my $data_time = "$1 $2 $3";
 
     if(check_new($data_site,$current_feed,$item_id)) {
       commit_entry($data_site,$current_feed,$item_id);
       foreach my $current_subscriber (@subscribers_array) {
-        $FeedReader::core->server_send("PRIVMSG $current_subscriber :\x02Unknown Horizons Forums\x02 | \x02$data_title\x02 by \x0303$data_author\x0F [ \x0314$data_date $data_time\x0F ] [ $data_link ]");
+        $FeedReader::core->server_send("PRIVMSG $current_subscriber :\x02Unknown Horizons Forums\x02 | \x02$data_title\x02 by \x0303$data_author\x0F [ \x0314$data_time\x0F ] [ $data_link ]");
       }
     }
   }

--- a/scripts/FeedReader/FeedWesnoth.pl
+++ b/scripts/FeedReader/FeedWesnoth.pl
@@ -71,9 +71,8 @@ foreach my $current_feed (@feed_array) {
 
     my ($data_link,$item_id,$data_author,$data_title,$data_date_full) = entry_to_data($current_entry,$link_regex,$item_id_regex,$author_regex,$title_regex,$date_regex);
     #2011-06-04T14:23:22-05:00
-    $data_date_full =~ m/^([0-9]+)-([0-9]+)-([0-9]+)T([0-9]+):([0-9]+):([0-9]+)[+-][0-9]+:[0-9]+$/i;
-    my $data_date = "$2-$3-$1";
-    my $data_time = "$4:$5";
+    $data_date_full =~ m/^([0-9]+-[0-9]+-[0-9]+)T([0-9]+:[0-9]+):[0-9]+([+-][0-9]+:[0-9]+)$/i;
+    my $data_time = "$1 $2 $3";
 
     if(check_new($data_site,$current_feed,$item_id)) {
       commit_entry($data_site,$current_feed,$item_id);
@@ -82,7 +81,7 @@ foreach my $current_feed (@feed_array) {
         if ($data_link =~ /^http:\/\/forums\.wesnoth\.org\/viewtopic\.php\?t=[0-9]+&p=([0-9]+)#p[0-9]+$/) {
           $data_link = "http://r.wesnoth.org/p$1";
         }
-        $FeedReader::core->server_send("PRIVMSG $current_subscriber :\x02Wesnoth Forums\x02 | \x02$data_title\x02 by \x0303$data_author\x0F [ \x0314$data_date $data_time\x0F ] [ $data_link ]");
+        $FeedReader::core->server_send("PRIVMSG $current_subscriber :\x02Wesnoth Forums\x02 | \x02$data_title\x02 by \x0303$data_author\x0F [ \x0314$data_time\x0F ] [ $data_link ]");
       }
     }
   }


### PR DESCRIPTION
(1) Stop mangling the nice standard ISO 8601 datestamps into… some
perverted format that as far as I know isn’t even really used anywhere.

(2) Stop capturing sequential elements of the input then outputting them
idem; merge these needlessly separate captures.

(3) Stop capturing elements of the input that are not subsequently used;
delete these unnecessary captures.

(4) Merge the needlessly separate $data_date variables into the
$data_time variables.

(5) Include timezones in the timestamps.