### PR TITLE
Tweets: Do not misparse (e.g.) ‘#1’ as a hashtag.

### DIFF
--- a/scripts/StreamReader/StreamTwitter.pl
+++ b/scripts/StreamReader/StreamTwitter.pl
@@ -102,7 +102,7 @@ while (my $line = <$read_pipe>) {
       }
     }
 
-    $text =~ s/(#[a-z0-9]+)/\x0312$1\x0F/ig; # Color hashtags
+    $text =~ s/(#[a-z][a-z0-9]*)/\x0312$1\x0F/ig; # Color hashtags
     $text =~ s/^RT (@\w{1,15}): /(\x0314RT $1\x0F) /; # Color retweets
     $text =~ s/[\r\n]+/ /ig; # Remove newlines
 


### PR DESCRIPTION
In Twitter reports, prevent ‘#’-prefixed US-ASCII-alphanumeric sequences
starting with a US-ASCII digit from being misinterpreted as hashtags.