### PR TITLE
Tweets: Properly parse hashtags with underscores.

### DIFF
--- a/parsers/plugin_parser/plugins/conversation/quotes.txt
+++ b/parsers/plugin_parser/plugins/conversation/quotes.txt
@@ -345,3 +345,8 @@
 #2
 - I was picturing Gambit shirtless and smothered in brown sugar. I had to read back a bit to understand what he was talking about. Not a bad mental image though.
 -Sometimes when I go to the toilet and someone's left their pee in there, I'll just sit for a while and breathe it in. It's very relaxing.
+
+*Dagmar
+#1
+- So, when you're reading the tutorials if they start talking abouti non-blocking I/O back away slowly.
+

--- a/scripts/StreamReader/StreamTwitter.pl
+++ b/scripts/StreamReader/StreamTwitter.pl
@@ -102,7 +102,7 @@ while (my $line = <$read_pipe>) {
       }
     }
 
-    $text =~ s/(#[a-z][a-z0-9]*)/\x0312$1\x0F/ig; # Color hashtags
+    $text =~ s/(#[a-z][a-z0-9_]*)/\x0312$1\x0F/ig; # Color hashtags
     $text =~ s/^RT (@\w{1,15}): /(\x0314RT $1\x0F) /; # Color retweets
     $text =~ s/[\r\n]+/ /ig; # Remove newlines
 


### PR DESCRIPTION
In Twitter reports, properly recognize and highlight hashtags that contain
underscores.

Previously, it appears that hashtags containing underscores would have
been recognized and highlighted only up until the first underscore,
i.e., the first underscore would have been misinterpreted as terminating
the hashtag, and not included in the hashtag.