### PR TITLE
Added &quote and &remember commands.

### DIFF
--- a/modules/PluginParser/Conversation/Quotes.pm
+++ b/modules/PluginParser/Conversation/Quotes.pm
@@ -1,0 +1,133 @@
+package PluginParser::Conversation::Quotes;
+use strict;
+use warnings;
+use IRC::Freenode::Specifications;
+use PluginParser::Maintenance::Memory;
+our @ISA = qw(Exporter);
+our @EXPORT_OK = qw(match);
+
+sub match {
+  my ($self,$core) = @_;
+  if($core->{'receiver_nick'} ne $core->{'botname'}) { return ''; }
+  if($core->{'event'} ne 'on_public_message' and $core->{'event'} ne 'on_private_message') { return ''; }
+
+
+  if($core->{'message'} =~ /^quote (\d+) $validNick$/) {
+    return recall_quote($core,$core->{'receiver_chan'},$core->{'sender_nick'},$2,int($1));
+  }
+
+  if($core->{'message'} =~ /^quote $validNick$/) {
+    return recall_quote($core,$core->{'receiver_chan'},$core->{'sender_nick'},$1);
+  }
+
+  if($core->{'message'} =~ /^quote $validNick (.+)$/) {
+    return recall_topical_quote($core,$core->{'receiver_chan'},$core->{'sender_nick'},$1,$2);
+  }
+
+  if($core->{'message'} =~ /^remember $validNick (.+)$/) {
+    return remember_quote($core,$core->{'receiver_chan'},$core->{'sender_nick'},$1,$2);
+  }
+
+
+  return '';
+}
+
+sub get_quote_count {
+  my ($core,$author) = @_;
+
+  return $core->value_get('quote:counts',lc($author)) || 0;
+}
+
+sub add_quote {
+  my ($core,$author,$message) = @_;
+  my $id = $core->value_increment('quote:counts',lc($author),1);
+
+  $core->value_set('quote:messages',lc($author).'#'.$id,$message);
+
+  return $id;
+}
+
+sub get_quote {
+  my ($core,$author,$id) = @_;
+
+  if(!defined($id)) {
+    $id = int(rand(get_quote_count($core,$author))) + 1;
+  }
+
+  my $message = $core->value_get('quote:messages',lc($author).'#'.$id);
+
+  if ($message) {
+    return "\"${message}\" - ${author} ${id}";
+  }
+
+  return '';
+}
+
+sub recall_quote {
+  my ($core,$chan,$target,$author,$id) = @_;
+
+  if (!get_quote_count($core,$author)) {
+    $core->{'output'}->parse("MESSAGE>${chan}>${target}: I don't remember anything from $author.");
+    return '';
+  }
+
+  my $message = get_quote($core,$author,$id);
+
+  if (!$message) {
+    $core->{'output'}->parse("MESSAGE>${chan}>${target}: I don't remember that quote.");
+    return '';
+  }
+
+  $core->{'output'}->parse("MESSAGE>${chan}>${target}: ${message}");
+}
+
+sub recall_topical_quote {
+  my ($core,$chan,$target,$author,$topic) = @_;
+
+  if (!get_quote_count($core,$author)) {
+    $core->{'output'}->parse("MESSAGE>${chan}>${target}: I don't remember anything from $author.");
+    return '';
+  }
+
+  my $message;
+  for my $id (1..get_quote_count($core,$author)) {
+    next unless $core->value_get('quote:messages',lc($author).'#'.$id) =~ /\Q$topic/i;
+    $message = get_quote($core,$author, $id);
+    last;
+  }
+
+  if (!$message) {
+    $core->{'output'}->parse("MESSAGE>${chan}>${target}: I don't remember that quote.");
+    return '';
+  }
+
+  $core->{'output'}->parse("MESSAGE>${chan}>${target}: ${message}");
+}
+
+
+sub remember_quote {
+  my ($core,$chan,$target,$author,$message) = @_;
+
+  if ($author eq $target) {
+    $core->{'output'}->parse("MESSAGE>${chan}>${target}: You're not that memorable to me.");
+    return '';
+  }
+
+  my @messages = retrieve_messages($core,$chan);
+  my $match;
+
+  for my $log (@messages) {
+    next unless $log->{'author'} eq $author;
+    next unless $log->{'message'} =~ /\Q$message/i;
+    $match = $log;
+    last;
+  }
+
+  if ($match) {
+    my $id = add_quote($core,$match->{'author'},$match->{'message'});
+    my $quote = get_quote($core,$match->{'author'},$id);
+    $core->{'output'}->parse("MESSAGE>${chan}>${target}: Remembered ${quote}");
+  } else {
+    $core->{'output'}->parse("MESSAGE>${chan}>${target}: I don't remember what ${author} said about ${message}");
+  }
+}

--- a/modules/PluginParser/Maintenance/Memory.pm
+++ b/modules/PluginParser/Maintenance/Memory.pm
@@ -1,0 +1,42 @@
+package PluginParser::Maintenance::Memory;
+use strict;
+use warnings;
+our @ISA = qw(Exporter);
+our @EXPORT = qw(retrieve_messages);
+our @EXPORT_OK = qw(match);
+
+sub match {
+  my ($self,$core) = @_;
+  if($core->{'event'} ne 'on_public_message') { return ''; }
+
+  return record_line($core,$core->{'receiver_chan'},$core->{'sender_nick'},$core->{'message'});
+}
+
+sub retrieve_messages {
+    my ($core,$channel) = @_;
+    my $pointer = $core->value_get('memory:messages',$channel.':pointer') || 0;
+    my $count = $core->value_get('memory:messages',$channel.':count') || 0;
+    my @result;
+
+    for my $index (($pointer..$count-1),(0..$pointer-1)) {
+        my $author = $core->value_get('memory:messages',$channel.':'.$index.':author');
+        my $message = $core->value_get('memory:messages',$channel.':'.$index.':message');
+        push(@result,{'author'=>$author,'message'=>$message});
+    }
+
+    return @result;
+}
+
+sub record_line {
+  my ($core,$channel,$nick,$message) = @_;
+
+  my $maxCount = 20;
+  my $count = $core->value_get('memory:messages',$channel.':count') || 0;
+  my $pointer = $core->value_get('memory:messages',$channel.':pointer') || 0;
+  $core->value_set('memory:messages',$channel.':'.$pointer.':author',$nick);
+  $core->value_set('memory:messages',$channel.':'.$pointer.':message',$message);
+  $core->value_set('memory:messages',$channel.':pointer',($pointer + 1) % $maxCount);
+  if ($count < $maxCount) {
+    $core->value_set('memory:messages',$channel.':count', $count + 1);
+  }
+}

--- a/parsers/plugin_parser2/jane.pl
+++ b/parsers/plugin_parser2/jane.pl
@@ -13,6 +13,7 @@ if($core->{'childid'} eq 'fork10' && $core->{'botname'} =~ /^janebot_*$/) {
 module_load('PluginParser::Maintenance::Autojoin');
 module_load('PluginParser::Maintenance::NickBump');
 module_load('PluginParser::Maintenance::ServerPing');
+module_load('PluginParser::Maintenance::Memory');
 #module_load('PluginParser::Maintenance::StateManagement');
 module_load('PluginParser::Basic::About');
 module_load('PluginParser::Basic::CTCP');
@@ -21,6 +22,7 @@ module_load('PluginParser::Staff::JoinPart');
 module_load('PluginParser::Temperature');
 module_load('PluginParser::Time');
 module_load('PluginParser::Conversation::EDBlock');
+module_load('PluginParser::Conversation::Quotes');
 module_load('PluginParser::Internet::FetchTitle');
 module_load('PluginParser::Internet::Youtube');
 module_load('PluginParser::Internet::Steam');


### PR DESCRIPTION
Two commands that are classic use:

- `&quote Dinnerbone` will pick a random Dinnerbone quote.
- `&quote 1 Dinnerbone` will pick the quote id 1 from Dinnerbone.

And two new ones:

- `&remember Dinnerbone butts` will add a quote for the last line Dinnerbone said about butts.
- `&quote Dinnerbone butts` will pick the quote from Dinnerbone that was about butts.


To do the `&remember`, I added a per-channel memory of 20 lines so that it can look back into the chat. This can be used for other commands later for contextual information (ie spam detection, or `&youtube` without ID to be able to show info on the vid someone just posted)

Anybody may do `&remember`, but they cannot `&remember` their own messages. It also doesn't support quote aliases but that's trivial to add in if it's needed.