### PR TITLE
Use reddit shortlink when announcing new reddit posts

### DIFF
--- a/scripts/FeedReddit.pl
+++ b/scripts/FeedReddit.pl
@@ -54,7 +54,7 @@ if($json && scalar($json->{'data'}->{'children'}[0])) {
     my $title = decode_entities($post->{'title'});
     my $author = '/u/'.$post->{'author'};
     (my $name = $post->{'name'}) =~ s|^t3_||;
-    my $short_url = "https://reddit.com/r/${subreddit}/${name}";
+    my $short_url = "https://redd.it}/${name}";
     my $lcsubreddit = lc($subreddit);
 
     if(!$subscribers{$lcsubreddit}) { $subscribers{$lcsubreddit} = $core->value_get('feed_subscriptions:reddit',$lcsubreddit); }


### PR DESCRIPTION
The subreddit is already mentioned in the announcement, so it's just a waste of space to have it again in the url.  Also, apparently github's editor removed an errant space elsewhere in the file.