### PR TITLE
Prevent &remember from matching substrings.

### DIFF
--- a/modules/PluginParser/Conversation/Quotes.pm
+++ b/modules/PluginParser/Conversation/Quotes.pm
@@ -160,7 +160,7 @@ sub remember_quote {
 
   for my $log (reverse(@messages)) {
     next unless $log->{'author'} eq $author;
-    next unless $log->{'message'} =~ /\Q$message/i;
+    next unless $log->{'message'} =~ /\b\Q$message\E\b/i;
     $match = $log;
     last;
   }


### PR DESCRIPTION
As mentioned in #74, &remember can match substrings (e.g. "&remember x10A94 me" can match the word "re**me**mber"). Checking for word boundaries around the match string should resolve the issue.