### PR TITLE
Use https when linking to a video in "&youtube" response

### DIFF
--- a/modules/PluginParser/Internet/Youtube.pm
+++ b/modules/PluginParser/Internet/Youtube.pm
@@ -62,7 +62,7 @@ sub youtube {
     my $restrictions = "(\x0314no region restrictions\x0F)";
     if($json->{'contentDetails'}->{'regionRestriction'}) { $restrictions = "(\x0307unavailable in some regions\x0F)"; }
 
-    $core->{'output'}->parse("MESSAGE>${chan}>${target}: \x02\"${title}\"\x02 \x0306[${hours}:${minutes}:${seconds}]\x0F (by \x0303${author}\x0F) \x0314${views}\x0F views, \x0303${likes}\x0F likes, \x0304${dislikes}\x0F dislikes http://youtu.be/${video} ${restrictions}");
+    $core->{'output'}->parse("MESSAGE>${chan}>${target}: \x02\"${title}\"\x02 \x0306[${hours}:${minutes}:${seconds}]\x0F (by \x0303${author}\x0F) \x0314${views}\x0F views, \x0303${likes}\x0F likes, \x0304${dislikes}\x0F dislikes https://youtu.be/${video} ${restrictions}");
   }
   else {
     $core->{'output'}->parse("MESSAGE>${chan}>${target}: That video does not exist.");


### PR DESCRIPTION
Gambot currently uses `http` whenever it links to a YouTube video in a `&youtube` response.
As YouTube supports https, it's better to use https in the URL as auto pre-fetching clients will use https to fetch info about the page.